### PR TITLE
fix: add Bootstrap.server.lua to create Binds folder on server start

### DIFF
--- a/src/server/Bootstrap.server.lua
+++ b/src/server/Bootstrap.server.lua
@@ -1,0 +1,63 @@
+-- Bootstrap.server.lua
+-- Runs first on the server (all other scripts yield on WaitForChild("Binds")).
+-- Creates the Binds folder in ReplicatedStorage with every BindableEvent and
+-- BindableFunction that the other server scripts depend on.
+
+local RS = game:GetService("ReplicatedStorage")
+
+-- Safety: if something already created Binds (e.g. from an old Studio save),
+-- don't create a duplicate.
+if RS:FindFirstChild("Binds") then
+    print("[Bootstrap] Binds already exists — skipping creation")
+    return
+end
+
+local binds = Instance.new("Folder")
+binds.Name = "Binds"
+
+-- BindableEvents -----------------------------------------------------------
+-- DamagePlayer   : BombSystem -> PlayerManager  (player, dmg, bombType)
+-- ResetPlayers   : RoundManager -> PlayerManager
+-- StartGame      : RoundManager -> PlayerManager
+-- ScatterPlayers : RoundManager -> PlayerManager
+-- HealPlayers    : RoundManager -> PlayerManager (healPct)
+-- StartBombs     : RoundManager -> BombSystem   (difficulty, hotZone, destroyChance, roundNum)
+-- StopBombs      : RoundManager -> BombSystem
+-- AwardRoundCoins: RoundManager -> CoinManager  (roundNum, survivors, isVictory)
+local bindableEvents = {
+    "DamagePlayer",
+    "ResetPlayers",
+    "StartGame",
+    "ScatterPlayers",
+    "HealPlayers",
+    "StartBombs",
+    "StopBombs",
+    "AwardRoundCoins",
+}
+
+for _, name in ipairs(bindableEvents) do
+    local e = Instance.new("BindableEvent")
+    e.Name = name
+    e.Parent = binds
+end
+
+-- BindableFunctions --------------------------------------------------------
+-- GetAlivePlayers: RoundManager invokes -> PlayerManager handles, returns list
+local bindableFunctions = {
+    "GetAlivePlayers",
+}
+
+for _, name in ipairs(bindableFunctions) do
+    local f = Instance.new("BindableFunction")
+    f.Name = name
+    f.Parent = binds
+end
+
+-- Parent last so WaitForChild listeners fire only once the folder is complete
+binds.Parent = RS
+
+print(string.format(
+    "[Bootstrap] Binds created — %d BindableEvents, %d BindableFunctions",
+    #bindableEvents,
+    #bindableFunctions
+))


### PR DESCRIPTION
## Root Cause

Every server script (`BombSystem`, `PlayerManager`, `RoundManager`) opens with:

```lua
local binds = RS:WaitForChild("Binds")
```

…but **nothing was ever creating the `Binds` folder** in ReplicatedStorage. All three scripts would hang indefinitely on that `WaitForChild`, so `ScatterPlayers` (and every other bind) was never connected or fired.

## Fix

Adds `src/server/Bootstrap.server.lua` — a lightweight, no-yield script that creates the `Binds` folder and populates it with all required `BindableEvent` and `BindableFunction` instances before any other script can use them:

| Name | Type | Direction |
|---|---|---|
| `DamagePlayer` | BindableEvent | BombSystem → PlayerManager |
| `ResetPlayers` | BindableEvent | RoundManager → PlayerManager |
| `StartGame` | BindableEvent | RoundManager → PlayerManager |
| `ScatterPlayers` | BindableEvent | RoundManager → PlayerManager |
| `HealPlayers` | BindableEvent | RoundManager → PlayerManager |
| `StartBombs` | BindableEvent | RoundManager → BombSystem |
| `StopBombs` | BindableEvent | RoundManager → BombSystem |
| `AwardRoundCoins` | BindableEvent | RoundManager → CoinManager |
| `GetAlivePlayers` | BindableFunction | RoundManager ↔ PlayerManager |

The folder is parented **last**, so any `WaitForChild("Binds")` listeners only fire once all children are already in place — avoiding a secondary race between the folder appearing and individual event `WaitForChild` calls resolving.

A safety guard (`FindFirstChild("Binds")`) prevents duplicate folders if the Studio DataModel happens to have a static Binds folder from an earlier save.

Closes #5