### PR TITLE
Fix: CoinManager uses WaitForChild instead of creating duplicate AwardRoundCoins event

### DIFF
--- a/src/server/CoinManager.server.lua
+++ b/src/server/CoinManager.server.lua
@@ -132,10 +132,9 @@ GameEvents.RoundUpdate.OnServerEvent:Connect(function() end)
 -- We need to listen to RoundUpdate on the server... but it's FireAllClients (server→client)
 -- So we need a different approach: hook into the RoundManager's round completion
 
--- Create a bindable for coin awards
-local coinBind = Instance.new("BindableEvent")
-coinBind.Name = "AwardRoundCoins"
-coinBind.Parent = binds
+-- Use the AwardRoundCoins BindableEvent created by Bootstrap
+-- (do NOT create a new one — Bootstrap owns all Binds instances)
+local coinBind = binds:WaitForChild("AwardRoundCoins")
 
 coinBind.Event:Connect(function(roundNumber, survivors, isVictory)
     local COINS_PER_ROUND = 5


### PR DESCRIPTION
## What was wrong

`CoinManager.server.lua` was creating its own `AwardRoundCoins` BindableEvent and parenting it to the `Binds` folder — but `Bootstrap.server.lua` already creates one with the same name at startup.

This meant:
- `RoundManager` called `binds:FindFirstChild("AwardRoundCoins")` and got **Bootstrap's copy**
- `CoinManager` listened on `.Event` of **its own copy** — a completely different instance
- The event fired into the void; CoinManager never heard it, so coins were never awarded

## What changed

In `src/server/CoinManager.server.lua`, replaced:
```lua
local coinBind = Instance.new("BindableEvent")
coinBind.Name = "AwardRoundCoins"
coinBind.Parent = binds
```
with:
```lua
local coinBind = binds:WaitForChild("AwardRoundCoins")
```

This follows the same pattern every other server script uses — Bootstrap owns all `Binds` instances, other scripts retrieve them with `WaitForChild`.

Closes #8