### PR TITLE
Add collectible coin system for map pickups

### DIFF
--- a/src/client/HUD/CoinHUD.lua
+++ b/src/client/HUD/CoinHUD.lua
@@ -1,5 +1,6 @@
 -- HUD/CoinHUD: Coin display positioned left of HP bar + earn animations
 -- Shows real-time coin count with flash + floating "+X" popup on earn.
+-- Also handles pickup VFX for collectible map coins.
 
 local ctx -- set via init()
 
@@ -98,6 +99,46 @@ function M.init(context)
             TextStrokeTransparency = 1,
         }):Play()
         ctx.Debris:AddItem(popup, 1.2)
+    end)
+
+    -- Map coin pickup VFX: gold particle burst at collection point
+    ctx.GameEvents:WaitForChild("CoinPickup").OnClientEvent:Connect(function(pos, collectorId)
+        local vfxPart = Instance.new("Part")
+        vfxPart.Size = Vector3.new(1, 1, 1)
+        vfxPart.Position = pos
+        vfxPart.Anchored = true
+        vfxPart.CanCollide = false
+        vfxPart.Transparency = 1
+        vfxPart.Parent = workspace
+
+        -- Gold sparkle burst
+        local emitter = Instance.new("ParticleEmitter")
+        emitter.Color = ColorSequence.new({
+            ColorSequenceKeypoint.new(0, Color3.fromRGB(255, 220, 50)),
+            ColorSequenceKeypoint.new(1, Color3.fromRGB(255, 180, 30)),
+        })
+        emitter.Size = NumberSequence.new({
+            NumberSequenceKeypoint.new(0, 1.0),
+            NumberSequenceKeypoint.new(1, 0),
+        })
+        emitter.Transparency = NumberSequence.new({
+            NumberSequenceKeypoint.new(0, 0),
+            NumberSequenceKeypoint.new(0.7, 0.3),
+            NumberSequenceKeypoint.new(1, 1),
+        })
+        emitter.Lifetime = NumberRange.new(0.4, 0.8)
+        emitter.Speed = NumberRange.new(8, 16)
+        emitter.SpreadAngle = Vector2.new(360, 360)
+        emitter.Rate = 0  -- burst only
+        emitter.LightEmission = 1
+        emitter.LightInfluence = 0.2
+        emitter.Parent = vfxPart
+
+        -- Emit burst
+        emitter:Emit(15)
+
+        -- Cleanup after particles fade
+        ctx.Debris:AddItem(vfxPart, 1.5)
     end)
 end
 

--- a/src/server/Bootstrap.server.lua
+++ b/src/server/Bootstrap.server.lua
@@ -17,6 +17,7 @@ if not RS:FindFirstChild("GameEvents") then
         "BombLanded",
         "LeaderboardUpdate",
         "CoinUpdate",
+        "CoinPickup",
         "LavaContact",
         "MissileLockOn",
         "MissileUpdate",
@@ -52,6 +53,9 @@ binds.Name = "Binds"
 -- StartBombs     : RoundManager -> BombSystem   (difficulty, hotZone, destroyChance, roundNum)
 -- StopBombs      : RoundManager -> BombSystem
 -- AwardRoundCoins: RoundManager -> CoinManager  (roundNum, survivors, isVictory)
+-- SpawnMapCoins  : RoundManager -> CoinSpawner  (spawn collectible coins on arena)
+-- CleanupMapCoins: RoundManager -> CoinSpawner  (remove all map coins)
+-- AwardCoinPickup: CoinSpawner  -> CoinManager  (player, amount, reason)
 local bindableEvents = {
     "DamagePlayer",
     "ResetPlayers",
@@ -61,6 +65,9 @@ local bindableEvents = {
     "StartBombs",
     "StopBombs",
     "AwardRoundCoins",
+    "SpawnMapCoins",
+    "CleanupMapCoins",
+    "AwardCoinPickup",
 }
 
 for _, name in ipairs(bindableEvents) do

--- a/src/server/CoinManager.server.lua
+++ b/src/server/CoinManager.server.lua
@@ -1,5 +1,6 @@
 -- Handles: coin earning per round, DataStore persistence, leaderstats display
 -- Coins: 5 per round survived, 50 bonus for full survive (all 7 rounds)
+-- Also handles map coin pickups via AwardCoinPickup BindableEvent
 
 local Players = game:GetService("Players")
 local DataStoreService = game:GetService("DataStoreService")
@@ -160,4 +161,11 @@ coinBind.Event:Connect(function(roundNumber, survivors, isVictory)
     end
 end)
 
-print("[CoinManager v1] Ready — coins, DataStore, leaderstats!")
+---------- MAP COIN PICKUPS (from CoinSpawner) ----------
+local pickupBind = binds:WaitForChild("AwardCoinPickup")
+pickupBind.Event:Connect(function(player, amount, reason)
+    if not player or not player.Parent then return end
+    awardCoins(player, amount, reason or "Coin Pickup")
+end)
+
+print("[CoinManager v2] Ready — coins, DataStore, leaderstats, map pickups!")

--- a/src/server/CoinSpawner.server.lua
+++ b/src/server/CoinSpawner.server.lua
@@ -1,0 +1,227 @@
+-- CoinSpawner v1: Physical collectible coins on the arena map
+-- Server-authoritative: spawning, collision detection, validation, reward triggering.
+-- Does NOT directly modify player data — fires AwardCoinPickup for CoinManager.
+
+local Players = game:GetService("Players")
+local RS = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local Config = require(RS:WaitForChild("GameConfig"))
+local MapManager = require(RS:WaitForChild("MapManager"))
+local SFX = require(RS:WaitForChild("SoundManager"))
+local GameEvents = RS:WaitForChild("GameEvents")
+local binds = RS:WaitForChild("Binds")
+
+local activeCoins = {}      -- id -> {part, collected, spawnPos, baseY}
+local coinFolder = nil
+local spinConn = nil
+local nextId = 0
+local collectCD = {}        -- userId -> last collect tick
+
+-- Config values (with defaults)
+local COUNT     = Config.COIN_SPAWN_COUNT or 15
+local REWARD    = Config.COIN_REWARD or 2
+local RESPAWN   = Config.COIN_RESPAWN_TIME or 10
+local SPIN_SPD  = Config.COIN_SPIN_SPEED or 2
+local BOB_AMP   = Config.COIN_BOB_HEIGHT or 0.5
+
+---------- COIN PART CREATION ----------
+local function makeCoin(pos, id)
+    local coin = Instance.new("Part")
+    coin.Name = "MapCoin_" .. id
+    coin.Shape = Enum.PartType.Cylinder
+    coin.Size = Vector3.new(0.4, 2.5, 2.5)
+    coin.CFrame = CFrame.new(pos) * CFrame.Angles(0, 0, math.rad(90))
+    coin.Anchored = true
+    coin.CanCollide = false
+    coin.Material = Enum.Material.Neon
+    coin.Color = Color3.fromRGB(255, 200, 50)
+    coin.Parent = coinFolder
+
+    -- Gold glow
+    local light = Instance.new("PointLight")
+    light.Color = Color3.fromRGB(255, 200, 50)
+    light.Brightness = 1.0
+    light.Range = 14
+    light.Parent = coin
+
+    -- Billboard "$" indicator
+    local bb = Instance.new("BillboardGui")
+    bb.Size = UDim2.new(0, 28, 0, 28)
+    bb.StudsOffset = Vector3.new(0, 2.5, 0)
+    bb.AlwaysOnTop = false
+    bb.Parent = coin
+
+    local lbl = Instance.new("TextLabel")
+    lbl.Size = UDim2.new(1, 0, 1, 0)
+    lbl.BackgroundTransparency = 1
+    lbl.Font = Enum.Font.GothamBold
+    lbl.TextSize = 18
+    lbl.TextColor3 = Color3.fromRGB(255, 220, 50)
+    lbl.TextStrokeTransparency = 0.3
+    lbl.TextStrokeColor3 = Color3.fromRGB(100, 70, 0)
+    lbl.Text = "$"
+    lbl.Parent = bb
+
+    return coin
+end
+
+---------- RANDOM POSITION ON MAP SURFACE ----------
+local function randomCoinPos()
+    local half = MapManager.GetBounds()
+    local inset = 0.15
+    local lo = -half * (1 - inset * 2)
+    local hi =  half * (1 - inset * 2)
+
+    for _ = 1, 25 do
+        local rx = lo + math.random() * (hi - lo)
+        local rz = lo + math.random() * (hi - lo)
+
+        -- Skip lava cells
+        if MapManager.IsOverLava(rx, rz) then continue end
+
+        -- Prefer mid/high tiers (avoid valleys near lava)
+        local tier = MapManager.GetTierAt(rx, rz)
+        if tier == "low" then continue end
+
+        -- Need a valid surface
+        local surfY = MapManager.GetSurfaceY(rx, rz)
+        if not surfY or surfY < -20 then continue end
+
+        -- Min spacing between coins (15 studs)
+        local tooClose = false
+        for _, d in pairs(activeCoins) do
+            if d.part and d.part.Parent and not d.collected then
+                local dx = rx - d.spawnPos.X
+                local dz = rz - d.spawnPos.Z
+                if dx * dx + dz * dz < 225 then tooClose = true; break end
+            end
+        end
+        if tooClose then continue end
+
+        return Vector3.new(rx, surfY + 2.5, rz)
+    end
+    return nil
+end
+
+---------- COLLECTION LOGIC ----------
+local function onTouch(id, hit)
+    local d = activeCoins[id]
+    if not d or d.collected then return end
+
+    local char = hit.Parent
+    if not char then return end
+    local player = Players:GetPlayerFromCharacter(char)
+    if not player then return end
+
+    -- Per-player debounce (0.3s)
+    local now = tick()
+    if collectCD[player.UserId] and now - collectCD[player.UserId] < 0.3 then return end
+    collectCD[player.UserId] = now
+
+    -- Mark collected immediately (prevents double-collect)
+    d.collected = true
+
+    -- Award via CoinManager (keeps DataStore + leaderstats in sync)
+    local awardBind = binds:FindFirstChild("AwardCoinPickup")
+    if awardBind then
+        awardBind:Fire(player, REWARD, "Coin Pickup!")
+    end
+
+    -- Notify all clients for pickup VFX
+    local pickupEvent = GameEvents:FindFirstChild("CoinPickup")
+    if pickupEvent then
+        pickupEvent:FireAllClients(d.spawnPos, player.UserId)
+    end
+
+    -- Pickup sound (3D positional)
+    SFX.PlayAt("CoinPickup", d.spawnPos, {Volume = 0.6, MaxDistance = 60})
+
+    -- Destroy the coin part
+    if d.part and d.part.Parent then d.part:Destroy() end
+
+    -- Respawn after delay
+    if RESPAWN > 0 then
+        task.delay(RESPAWN, function()
+            if not coinFolder or not coinFolder.Parent then return end
+            spawnOne()
+        end)
+    end
+end
+
+---------- SPAWN ----------
+function spawnOne()
+    local pos = randomCoinPos()
+    if not pos then return end
+
+    nextId = nextId + 1
+    local id = nextId
+    local part = makeCoin(pos, id)
+
+    activeCoins[id] = {
+        part = part,
+        collected = false,
+        spawnPos = pos,
+        baseY = pos.Y,
+    }
+
+    part.Touched:Connect(function(hit) onTouch(id, hit) end)
+end
+
+local function spawnAll()
+    for _ = 1, COUNT do spawnOne() end
+    print("[CoinSpawner] Spawned " .. COUNT .. " map coins")
+end
+
+---------- SPIN + BOB ANIMATION (single Heartbeat for all coins) ----------
+local function startAnim()
+    if spinConn then spinConn:Disconnect() end
+    spinConn = RunService.Heartbeat:Connect(function()
+        local t = tick()
+        for _, d in pairs(activeCoins) do
+            if d.part and d.part.Parent and not d.collected then
+                local angle = t * SPIN_SPD * math.pi * 2
+                local bob = math.sin(t * 2) * BOB_AMP
+                d.part.CFrame = CFrame.new(d.spawnPos.X, d.baseY + bob, d.spawnPos.Z)
+                    * CFrame.Angles(0, angle, math.rad(90))
+            end
+        end
+    end)
+end
+
+local function stopAnim()
+    if spinConn then spinConn:Disconnect(); spinConn = nil end
+end
+
+---------- CLEANUP ----------
+local function cleanup()
+    stopAnim()
+    for _, d in pairs(activeCoins) do
+        if d.part and d.part.Parent then d.part:Destroy() end
+    end
+    activeCoins = {}
+    collectCD = {}
+    if coinFolder and coinFolder.Parent then coinFolder:Destroy() end
+    coinFolder = nil
+end
+
+---------- BINDABLE EVENT HOOKS ----------
+binds:WaitForChild("SpawnMapCoins").Event:Connect(function()
+    cleanup()
+    coinFolder = Instance.new("Folder")
+    coinFolder.Name = "MapCoins"
+    coinFolder.Parent = workspace
+    spawnAll()
+    startAnim()
+end)
+
+binds:WaitForChild("CleanupMapCoins").Event:Connect(function()
+    cleanup()
+end)
+
+-- Cleanup debounce on player leave
+Players.PlayerRemoving:Connect(function(p)
+    collectCD[p.UserId] = nil
+end)
+
+print("[CoinSpawner v1] Ready — collectible map coins!")

--- a/src/server/RoundManager.server.lua
+++ b/src/server/RoundManager.server.lua
@@ -325,6 +325,7 @@ while true do
 
     -- GO!
     GameEvents.RoundUpdate:FireAllClients("countdown_go", 0, 0, 1)
+    binds.SpawnMapCoins:Fire()  -- Spawn collectible coins on the arena
     task.wait(0.5)
 
     local gameOver = false
@@ -383,6 +384,7 @@ while true do
             end
             setLobbySpawns(true)
             clearHotZone()
+            binds.CleanupMapCoins:Fire()  -- Remove collectible coins
             GameEvents.RoundUpdate:FireAllClients("return_to_lobby")
             task.wait(0.5)
             binds.ResetPlayers:Fire()
@@ -405,6 +407,7 @@ while true do
                 task.wait(3)
                 setLobbySpawns(true)
                 clearHotZone()
+                binds.CleanupMapCoins:Fire()  -- Remove collectible coins
                 GameEvents.RoundUpdate:FireAllClients("return_to_lobby")
                 task.wait(0.5)
                 binds.ResetPlayers:Fire()

--- a/src/shared/GameConfig.lua
+++ b/src/shared/GameConfig.lua
@@ -47,6 +47,13 @@ return {
     MIN_PLAYERS = 1,           -- minimum players required to start (1 = solo/Studio-test friendly)
     LOBBY_COUNTDOWN = 5,       -- lobby countdown seconds before game drops players in
 
+    -- COLLECTIBLE MAP COINS
+    COIN_SPAWN_COUNT = 15,     -- number of coins spawned on the arena per game
+    COIN_REWARD = 2,           -- coins earned per pickup
+    COIN_RESPAWN_TIME = 10,    -- seconds before a collected coin respawns (0 = no respawn)
+    COIN_SPIN_SPEED = 2,       -- rotations per second
+    COIN_BOB_HEIGHT = 0.5,     -- vertical bob amplitude in studs
+
     -- BOMBS
     BOMB_INTERVAL_BASE = 1.2,
     BOMB_INTERVAL_MIN = 0.15,

--- a/src/shared/SoundManager.lua
+++ b/src/shared/SoundManager.lua
@@ -1,4 +1,4 @@
--- SoundManager v4: Fixed audio IDs, removed jingles
+-- SoundManager v5: Added CoinPickup sound
 local SoundManager = {}
 
 local SOUNDS = {
@@ -30,6 +30,9 @@ local SOUNDS = {
     LavaSizzle      = "rbxassetid://31758982",   -- Contact sizzle (same asset, different properties)
     RoundClear      = "rbxassetid://135165335432475", -- Round survived chime
     LandThud        = "rbxassetid://74054153559436",  -- Landing thud
+
+    -- Collectible coins
+    CoinPickup      = "rbxassetid://135165335432475", -- Coin pickup chime
 }
 
 -- Play a sound at a specific position in workspace (3D positional audio)


### PR DESCRIPTION
Closes #12

## Summary

Adds a physical collectible coin system where gold coins spawn on the arena map during rounds and can be picked up by players walking into them.

### Design decisions

- **Procedural spawning** on valid map surface tiles (avoids lava, valleys, and overlapping positions) since maps are procedurally generated each game
- **Server-authoritative** collection via `.Touched` with per-player debounce — no client trust for rewards
- **Integrated with existing CoinManager** via new `AwardCoinPickup` BindableEvent so DataStore persistence and leaderstats stay in sync
- **Single Heartbeat connection** animates all coins (spin + bob) — efficient even at 15 coins
- **Configurable** via GameConfig: spawn count, reward amount, respawn time, spin speed, bob height

### Changes

| File | Change |
|------|--------|
| `src/server/CoinSpawner.server.lua` | **NEW** — server-authoritative coin spawning, touch detection, collection validation, respawn logic |
| `src/server/Bootstrap.server.lua` | Added `CoinPickup` RemoteEvent, `SpawnMapCoins`/`CleanupMapCoins`/`AwardCoinPickup` BindableEvents |
| `src/shared/GameConfig.lua` | Added `COIN_SPAWN_COUNT`, `COIN_REWARD`, `COIN_RESPAWN_TIME`, `COIN_SPIN_SPEED`, `COIN_BOB_HEIGHT` |
| `src/server/CoinManager.server.lua` | Added `AwardCoinPickup` listener (routes pickups through existing award + DataStore flow) |
| `src/server/RoundManager.server.lua` | Fires `SpawnMapCoins` after GO, `CleanupMapCoins` on game over/victory |
| `src/shared/SoundManager.lua` | Added `CoinPickup` sound entry |
| `src/client/HUD/CoinHUD.lua` | Added `CoinPickup` listener for gold particle burst VFX at pickup location |

### How it works

1. After "GO!" in the round flow, `RoundManager` fires `SpawnMapCoins`
2. `CoinSpawner` places 15 gold Neon cylinder coins on valid mid/high tier tiles with PointLight glow and "$" BillboardGui
3. A single `Heartbeat` connection spins and bobs all coins
4. On `.Touched`, server validates: player exists, not already collected, debounce passed
5. Awards coins via `AwardCoinPickup` → `CoinManager.awardCoins()` (DataStore + leaderstats + CoinUpdate RemoteEvent)
6. Fires `CoinPickup` RemoteEvent for client-side gold particle burst VFX
7. Plays 3D positional pickup sound via SoundManager
8. Collected coins respawn after 10s (configurable)
9. All coins cleaned up on game over or victory

### Security

- Server creates, validates, and destroys coins — no client input trusted
- Double-collection prevented by immediate `collected = true` flag before any async work
- Per-player 0.3s debounce prevents rapid-fire exploits