### PR TITLE
Implement coin streak/combo mechanic

### DIFF
--- a/src/client/HUD/CoinHUD.lua
+++ b/src/client/HUD/CoinHUD.lua
@@ -1,10 +1,13 @@
--- HUD/CoinHUD: Coin display positioned left of HP bar + earn animations
+-- HUD/CoinHUD: Coin display positioned left of HP bar + earn animations + streak indicator
 -- Shows real-time coin count with flash + floating "+X" popup on earn.
--- Also handles pickup VFX for collectible map coins.
+-- Streak indicator shows "Nx STREAK!" with escalating color when chaining coins.
 
 local ctx -- set via init()
 
 local coinDisplay, coinIcon
+local streakLabel  -- shows "2x STREAK!" etc.
+local streakTween  -- current streak fade tween
+local streakHideThread  -- delayed hide thread
 
 local M = {}
 
@@ -50,6 +53,31 @@ function M.init(context)
     coinIcon.ZIndex = 6
     coinIcon.Parent = coinDisplay
 
+    ---------- STREAK INDICATOR ----------
+    streakLabel = Instance.new("TextLabel")
+    streakLabel.Name = "StreakLabel"
+    streakLabel.Size = UDim2.new(0, 160, 0, 28)
+    streakLabel.Position = UDim2.new(0.5, -195, 1, -48)
+    streakLabel.AnchorPoint = Vector2.new(1, 0.5)
+    streakLabel.BackgroundColor3 = Color3.fromRGB(40, 25, 0)
+    streakLabel.BackgroundTransparency = 0.4
+    streakLabel.BorderSizePixel = 0
+    streakLabel.Font = Enum.Font.GothamBold
+    streakLabel.TextSize = 14
+    streakLabel.TextColor3 = Color3.fromRGB(255, 200, 80)
+    streakLabel.TextStrokeTransparency = 0.3
+    streakLabel.TextStrokeColor3 = Color3.fromRGB(0, 0, 0)
+    streakLabel.Text = ""
+    streakLabel.TextXAlignment = Enum.TextXAlignment.Center
+    streakLabel.TextTransparency = 1
+    streakLabel.BackgroundTransparency = 1
+    streakLabel.ZIndex = 6
+    streakLabel.Parent = ctx.gui
+
+    local streakCorner = Instance.new("UICorner")
+    streakCorner.CornerRadius = UDim.new(0, 6)
+    streakCorner.Parent = streakLabel
+
     -- Initialize from leaderstats
     task.spawn(function()
         local ls = ctx.player:WaitForChild("leaderstats", 10)
@@ -66,7 +94,9 @@ function M.init(context)
 
     -- Coin earn animation: flash + floating popup
     ctx.GameEvents:WaitForChild("CoinUpdate").OnClientEvent:Connect(function(amount, total, reason)
-        coinDisplay.Text = tostring(total)
+        if total then
+            coinDisplay.Text = tostring(total)
+        end
         -- Flash gold
         ctx.TweenService:Create(coinDisplay, TweenInfo.new(0.15), {
             TextColor3 = Color3.fromRGB(255, 255, 150),
@@ -101,6 +131,60 @@ function M.init(context)
         ctx.Debris:AddItem(popup, 1.2)
     end)
 
+    ---------- STREAK EVENT HANDLER ----------
+    ctx.GameEvents:WaitForChild("CoinStreak").OnClientEvent:Connect(function(streakCount, multiplier)
+        -- Color escalates with streak: gold -> orange -> red-orange -> bright red
+        local streakColors = {
+            [2] = Color3.fromRGB(255, 220, 80),   -- warm gold
+            [3] = Color3.fromRGB(255, 180, 50),   -- orange-gold
+            [4] = Color3.fromRGB(255, 140, 40),   -- orange
+            [5] = Color3.fromRGB(255, 100, 30),   -- red-orange (max)
+        }
+        local bgColors = {
+            [2] = Color3.fromRGB(40, 25, 0),
+            [3] = Color3.fromRGB(50, 25, 0),
+            [4] = Color3.fromRGB(60, 20, 0),
+            [5] = Color3.fromRGB(70, 15, 0),
+        }
+        local textColor = streakColors[math.min(streakCount, 5)] or streakColors[5]
+        local bgColor = bgColors[math.min(streakCount, 5)] or bgColors[5]
+
+        streakLabel.Text = streakCount .. "x STREAK!"
+        streakLabel.TextColor3 = textColor
+        streakLabel.BackgroundColor3 = bgColor
+
+        -- Cancel any pending hide
+        if streakHideThread then
+            task.cancel(streakHideThread)
+            streakHideThread = nil
+        end
+
+        -- Pop-in animation
+        streakLabel.TextSize = 10
+        streakLabel.TextTransparency = 0
+        streakLabel.BackgroundTransparency = 0.4
+        ctx.TweenService:Create(streakLabel, TweenInfo.new(0.15, Enum.EasingStyle.Back, Enum.EasingDirection.Out), {
+            TextSize = 16 + math.min(streakCount - 2, 3) * 2,
+        }):Play()
+
+        -- Play streak sound
+        ctx.SFX.PlayUI("StreakUp", ctx.camera, {
+            Volume = 0.3 + math.min(streakCount - 2, 3) * 0.05,
+            PlaybackSpeed = 0.9 + math.min(streakCount - 2, 3) * 0.1,
+        })
+
+        -- Auto-hide after streak timeout + small buffer
+        streakHideThread = task.delay(3.0, function()
+            if streakLabel then
+                ctx.TweenService:Create(streakLabel, TweenInfo.new(0.5, Enum.EasingStyle.Quad, Enum.EasingDirection.In), {
+                    TextTransparency = 1,
+                    BackgroundTransparency = 1,
+                }):Play()
+            end
+            streakHideThread = nil
+        end)
+    end)
+
     -- Map coin pickup VFX: gold particle burst at collection point
     ctx.GameEvents:WaitForChild("CoinPickup").OnClientEvent:Connect(function(pos, collectorId)
         local vfxPart = Instance.new("Part")
@@ -111,7 +195,6 @@ function M.init(context)
         vfxPart.Transparency = 1
         vfxPart.Parent = workspace
 
-        -- Gold sparkle burst
         local emitter = Instance.new("ParticleEmitter")
         emitter.Color = ColorSequence.new({
             ColorSequenceKeypoint.new(0, Color3.fromRGB(255, 220, 50)),
@@ -129,15 +212,12 @@ function M.init(context)
         emitter.Lifetime = NumberRange.new(0.4, 0.8)
         emitter.Speed = NumberRange.new(8, 16)
         emitter.SpreadAngle = Vector2.new(360, 360)
-        emitter.Rate = 0  -- burst only
+        emitter.Rate = 0
         emitter.LightEmission = 1
         emitter.LightInfluence = 0.2
         emitter.Parent = vfxPart
 
-        -- Emit burst
         emitter:Emit(15)
-
-        -- Cleanup after particles fade
         ctx.Debris:AddItem(vfxPart, 1.5)
     end)
 end

--- a/src/server/Bootstrap.server.lua
+++ b/src/server/Bootstrap.server.lua
@@ -20,6 +20,7 @@ if not RS:FindFirstChild("GameEvents") then
         "LavaContact",
         "MissileLockOn",
         "MissileUpdate",
+        "CoinStreak",
     }
 
     for _, name in ipairs(remoteEvents) do

--- a/src/server/CoinSpawner.server.lua
+++ b/src/server/CoinSpawner.server.lua
@@ -1,7 +1,8 @@
--- CoinSpawner v1: Procedural coin spawning with collection, respawn, and polish
+-- CoinSpawner v2: Procedural coin spawning with collection, respawn, streaks, and polish
 -- Spawns coins on valid map tiles (mid/high tiers, avoids lava)
 -- Server-authoritative .Touched collection with debounce + collected flag
 -- Rewards routed via CoinManager using AwardCoinPickup BindableEvent
+-- Streak system: consecutive pickups within timeout earn multiplied rewards
 
 local Players = game:GetService("Players")
 local RS = game:GetService("ReplicatedStorage")
@@ -22,23 +23,58 @@ local CLUSTER_CHANCE = Config.COIN_CLUSTER_CHANCE or 0.15
 local CLUSTER_MIN = 2
 local CLUSTER_MAX = 4
 
+-- Streak config
+local STREAK_TIMEOUT = Config.COIN_STREAK_TIMEOUT or 2.5
+local STREAK_MAX = Config.COIN_STREAK_MAX_MULTIPLIER or 5
+
 ---------- STATE ----------
 local coinFolder = nil
 local activeCoins = {}   -- coin Part -> data table
 local heartbeatConn = nil
 local collectionDebounce = {}  -- userId -> tick
 
+-- Streak state per player: { count = number, lastPickup = number }
+local playerStreaks = {}
+
+---------- STREAK HELPERS ----------
+local function getStreak(userId)
+    if not playerStreaks[userId] then
+        playerStreaks[userId] = { count = 0, lastPickup = 0 }
+    end
+    return playerStreaks[userId]
+end
+
+local function resetStreak(userId)
+    playerStreaks[userId] = { count = 0, lastPickup = 0 }
+end
+
+local function updateStreak(userId)
+    local streak = getStreak(userId)
+    local now = tick()
+    if streak.count > 0 and (now - streak.lastPickup) <= STREAK_TIMEOUT then
+        streak.count = math.min(streak.count + 1, STREAK_MAX)
+    else
+        streak.count = 1
+    end
+    streak.lastPickup = now
+    return streak.count
+end
+
+-- Clean up streak data when player leaves
+Players.PlayerRemoving:Connect(function(player)
+    playerStreaks[player.UserId] = nil
+    collectionDebounce[player.UserId] = nil
+end)
+
 ---------- SPAWN WEIGHTING ----------
--- Higher weight = more likely. High tier and near-hazard tiles get bonus.
 local function getSpawnWeight(tier, gx, gz)
     local weight = 1.0
     if tier == "high" then
-        weight = 1.8   -- exposed to bombs, harder to reach = riskier
+        weight = 1.8
     elseif tier == "low" then
-        weight = 0.4   -- valleys are sheltered, less reward
+        weight = 0.4
     end
 
-    -- Bonus for tiles near lava (risky but valid)
     local G, T = Config.GRID, Config.TILE
     for dx = -2, 2 do
         for dz = -2, 2 do
@@ -50,7 +86,6 @@ local function getSpawnWeight(tier, gx, gz)
                     local isLava = MapManager.IsOverLava(wx, wz)
                     if isLava then
                         weight = weight * 1.4
-                        -- Only apply once
                         goto doneNearLava
                     end
                 end
@@ -132,14 +167,12 @@ local function createCoin(worldX, surfaceY, worldZ)
     coin.Material = Enum.Material.Neon
     coin.Color = Color3.fromRGB(255, 210, 50)
 
-    -- Glow
     local light = Instance.new("PointLight")
     light.Color = Color3.fromRGB(255, 220, 80)
     light.Brightness = 0.8
     light.Range = 12
     light.Parent = coin
 
-    -- "$" billboard
     local bbg = Instance.new("BillboardGui")
     bbg.Size = UDim2.new(0, 40, 0, 40)
     bbg.StudsOffset = Vector3.new(0, 0, 0)
@@ -155,7 +188,6 @@ local function createCoin(worldX, surfaceY, worldZ)
     label.Font = Enum.Font.GothamBold
     label.Parent = bbg
 
-    -- Pickup sound
     local sound = Instance.new("Sound")
     sound.SoundId = "rbxassetid://6895079853"
     sound.Volume = 0.5
@@ -222,9 +254,18 @@ local function onCoinTouched(coin, hit)
     -- Mark collected (server-authoritative, prevents any race)
     data.collected = true
 
+    -- Update streak and calculate multiplied reward
+    local streakCount = updateStreak(userId)
+    local multiplier = streakCount
+    local totalAward = COIN_VALUE * multiplier
+
     -- Sound
     local snd = coin:FindFirstChildOfClass("Sound")
-    if snd then snd:Play() end
+    if snd then
+        -- Pitch up slightly with streak for satisfying audio feedback
+        snd.PlaybackSpeed = 0.9 + math.min(streakCount - 1, 4) * 0.08 + math.random() * 0.1
+        snd:Play()
+    end
 
     -- Burst VFX
     playPickupBurst(coin.Position)
@@ -232,11 +273,20 @@ local function onCoinTouched(coin, hit)
     -- Award coins via BindableEvent -> CoinManager
     local awardBind = binds:FindFirstChild("AwardCoinPickup")
     if awardBind then
-        awardBind:Fire(player, COIN_VALUE, "Coin Pickup")
+        local reason = "Coin Pickup"
+        if streakCount >= 2 then
+            reason = streakCount .. "x Streak Pickup"
+        end
+        awardBind:Fire(player, totalAward, reason)
     end
 
-    -- Notify client HUD
-    GameEvents.CoinUpdate:FireClient(player, COIN_VALUE, nil, "Pickup")
+    -- Notify client HUD of coin earned (amount + total)
+    GameEvents.CoinUpdate:FireClient(player, totalAward, nil, "Pickup")
+
+    -- Notify client of streak state (for streak UI)
+    if streakCount >= 2 then
+        GameEvents.CoinStreak:FireClient(player, streakCount, multiplier)
+    end
 
     -- Hide coin
     coin.Transparency = 1
@@ -245,7 +295,7 @@ local function onCoinTouched(coin, hit)
     local light = coin:FindFirstChildOfClass("PointLight")
     if light then light.Enabled = false end
 
-    -- Schedule respawn with jitter (±COIN_RESPAWN_JITTER seconds)
+    -- Schedule respawn with jitter
     local jitter = (math.random() * 2 - 1) * COIN_RESPAWN_JITTER
     local respawnDelay = math.max(COIN_RESPAWN_TIME + jitter, 3)
     task.delay(respawnDelay, function()
@@ -254,7 +304,6 @@ local function onCoinTouched(coin, hit)
         coin.Transparency = 0
         if bbg then bbg.Enabled = true end
         if light then light.Enabled = true end
-        -- Re-randomize animation params for variety on respawn
         data.spinSpeed = 1.5 + math.random() * 1.0
         data.bobAmp = 0.3 + math.random() * 0.2
         data.bobOffset = math.random() * math.pi * 2
@@ -285,6 +334,11 @@ local function spawnCoins()
     collectionDebounce = {}
     if heartbeatConn then heartbeatConn:Disconnect(); heartbeatConn = nil end
 
+    -- Reset all streaks on map rebuild (new round)
+    for userId, _ in pairs(playerStreaks) do
+        resetStreak(userId)
+    end
+
     coinFolder = Instance.new("Folder")
     coinFolder.Name = "PickupCoins"
     coinFolder.Parent = workspace
@@ -295,14 +349,12 @@ local function spawnCoins()
         return
     end
 
-    -- Select base spawn points with weighted distribution
     local baseSpawns = weightedSelect(positions, COIN_COUNT)
     local spawnPoints = {}
 
     for _, pos in ipairs(baseSpawns) do
         table.insert(spawnPoints, pos)
 
-        -- Cluster chance: spawn extra coins nearby (10-20% of the time)
         if math.random() < CLUSTER_CHANCE then
             local clusterSize = math.random(CLUSTER_MIN - 1, CLUSTER_MAX - 1)
             for _ = 1, clusterSize do
@@ -324,12 +376,10 @@ local function spawnCoins()
         end
     end
 
-    -- Create coin instances
     for _, pos in ipairs(spawnPoints) do
         local coin = createCoin(pos.worldX, pos.surfaceY, pos.worldZ)
         coin.Parent = coinFolder
 
-        -- Per-coin animation variation for natural feel
         activeCoins[coin] = {
             collected = false,
             gx = pos.gx,
@@ -348,7 +398,7 @@ local function spawnCoins()
     end
 
     startAnimation()
-    print("[CoinSpawner] Spawned " .. #spawnPoints .. " coins (" .. #baseSpawns .. " base + clusters)")
+    print("[CoinSpawner v2] Spawned " .. #spawnPoints .. " coins (" .. #baseSpawns .. " base + clusters) — streaks enabled")
 end
 
 ---------- WATCH FOR MAP REBUILDS ----------
@@ -360,11 +410,10 @@ workspace.ChildAdded:Connect(function(child)
     end
 end)
 
--- If map already exists at load time
 if workspace:FindFirstChild("Map") then
     task.delay(1.0, function()
         spawnCoins()
     end)
 end
 
-print("[CoinSpawner v1] Ready — procedural coins with weighting, clusters, jitter")
+print("[CoinSpawner v2] Ready — procedural coins with weighting, clusters, jitter, streaks")

--- a/src/shared/GameConfig.lua
+++ b/src/shared/GameConfig.lua
@@ -71,4 +71,8 @@ return {
     COIN_RESPAWN_JITTER = 3,       -- ± random jitter on respawn (prevents wave patterns)
     COIN_PICKUP_VALUE = 1,         -- coins awarded per pickup
     COIN_CLUSTER_CHANCE = 0.15,    -- 15% chance a spawn point becomes a 2-4 coin cluster
+
+    -- COIN STREAK / COMBO
+    COIN_STREAK_TIMEOUT = 2.5,         -- seconds to collect next coin before streak resets
+    COIN_STREAK_MAX_MULTIPLIER = 5,    -- maximum streak multiplier cap
 }

--- a/src/shared/SoundManager.lua
+++ b/src/shared/SoundManager.lua
@@ -1,4 +1,4 @@
--- SoundManager v5: Added CoinPickup sound
+-- SoundManager v6: Added StreakUp sound for coin streak feedback
 local SoundManager = {}
 
 local SOUNDS = {
@@ -33,6 +33,7 @@ local SOUNDS = {
 
     -- Collectible coins
     CoinPickup      = "rbxassetid://135165335432475", -- Coin pickup chime
+    StreakUp        = "rbxassetid://135165335432475", -- Streak increment chime (same base, pitch-shifted in code)
 }
 
 -- Play a sound at a specific position in workspace (3D positional audio)


### PR DESCRIPTION
Closes #16

## What was missing
The coin pickup system awarded a flat 1 coin per pickup with no incentive to chain consecutive collections. Players had no reason to rush between coins or take risks near clusters.

## What changed

**5 files modified across server, client, and shared:**

### `GameConfig.lua`
- Added `COIN_STREAK_TIMEOUT = 2.5` (seconds between pickups to maintain streak)
- Added `COIN_STREAK_MAX_MULTIPLIER = 5` (cap on streak multiplier)

### `Bootstrap.server.lua`
- Added `CoinStreak` RemoteEvent for server→client streak notifications

### `CoinSpawner.server.lua` (v1 → v2)
- Added per-player streak tracking (`playerStreaks` table with count + lastPickup timestamp)
- On coin pickup: checks if previous pickup was within `STREAK_TIMEOUT`; if so, increments streak (capped at `STREAK_MAX`), otherwise resets to 1
- Awards `COIN_VALUE * streakCount` instead of flat `COIN_VALUE`
- Fires `CoinStreak` RemoteEvent to client when streak ≥ 2
- Pitches up the pickup sound slightly with streak count for audio feedback
- Cleans up streak state on player leave and map rebuild
- Streak resets implicitly on death (player can't collect coins while dead, so timeout expires)

### `CoinHUD.lua`
- Added streak indicator label ("2x STREAK!", "3x STREAK!", etc.) positioned above the coin display
- Escalating color scheme: warm gold (2x) → orange-gold (3x) → orange (4x) → red-orange (5x)
- Pop-in animation with `Back` easing on each streak increment
- Auto-fades after 3 seconds of no new streak events
- Plays `StreakUp` sound with increasing pitch per streak level

### `SoundManager.lua` (v5 → v6)
- Added `StreakUp` sound entry (uses same chime asset, pitch-shifted in calling code)

## Design decisions
- **Server-authoritative**: All streak logic runs on the server to prevent exploitation
- **Timeout-based reset**: Streak resets naturally via timeout (2.5s), so death/respawn doesn't need special handling — dead players simply can't collect coins
- **Cluster-friendly**: The 2.5s timeout is generous enough for multi-coin clusters but challenging for cross-map chaining
- **Minimal footprint**: No new BindableEvents needed; reuses existing `AwardCoinPickup` path for coin awards